### PR TITLE
Missing message after automatically joining a group (X-Post from d.o)

### DIFF
--- a/og_ui/og_ui.pages.inc
+++ b/og_ui/og_ui.pages.inc
@@ -170,7 +170,6 @@ function og_ui_confirm_subscribe_validate($form, &$form_state) {
  * Submit handler; Confirm OG membership.
  */
 function og_ui_confirm_subscribe_submit($form, &$form_state) {
-  global $user;
   $og_membership = $form_state['og_membership'];
   field_attach_submit('og_membership', $og_membership, $form, $form_state);
   $og_membership->save();
@@ -181,6 +180,7 @@ function og_ui_confirm_subscribe_submit($form, &$form_state) {
 
   if (entity_access('view', $group_type, $group)) {
     $redirect = entity_uri($group_type, $group);
+    drupal_set_message(t('You are now a member of @group.', array('@group' => entity_label($group_type, $group))));
   }
   else {
     // User doesn't have access to the group entity, so redirect to front page,


### PR DESCRIPTION
_Original issue https://www.drupal.org/node/2349693_

When a user has permission to automatically join a group, permission is granted and the page is reloaded but no message that anything was done is given.

Please add an appropriate message that the user has been added to the group.

Thanks!
